### PR TITLE
Kamailio config change (in run.sh) for "Table 'homer_data.sip_capture_call_%Y%m%d' doesn't exist"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docker pull qxip/homer-docker
 
 ### Run latest
 ```
-docker run -tid --name homer5 -p 80:80 -p 9060:9060 qxip/homer-docker
+docker run -tid --name homer5 -p 80:80 -p 9060:9060/udp qxip/homer-docker
 ```
 
 ### Local Build & Test

--- a/run.sh
+++ b/run.sh
@@ -137,6 +137,10 @@ perl -p -i -e "s/\{\{ DB_PASS \}\}/$DB_PASS/" $PATH_KAMAILIO_CFG
 perl -p -i -e "s/\{\{ DB_HOST \}\}/$DB_HOST/" $PATH_KAMAILIO_CFG
 perl -p -i -e "s/\{\{ DB_USER \}\}/$DB_USER/" $PATH_KAMAILIO_CFG
 
+# Change kamailio datestamp for sql tables
+sed -i -e 's/# $var(a) = $var(table) + "_" + $timef(%Y%m%d);/$var(a) = $var(table) + "_" + $timef(%Y%m%d);/' $PATH_KAMAILIO_CFG
+sed -i -e 's/$var(a) = $var(table) + "_%Y%m%d";/# doug removed -- $var(a) = $var(table) + "_%Y%m%d";/' $PATH_KAMAILIO_CFG
+
 # Make an alias, kinda.
 kamailio=$(which kamailio)
 

--- a/run.sh
+++ b/run.sh
@@ -139,7 +139,7 @@ perl -p -i -e "s/\{\{ DB_USER \}\}/$DB_USER/" $PATH_KAMAILIO_CFG
 
 # Change kamailio datestamp for sql tables
 sed -i -e 's/# $var(a) = $var(table) + "_" + $timef(%Y%m%d);/$var(a) = $var(table) + "_" + $timef(%Y%m%d);/' $PATH_KAMAILIO_CFG
-sed -i -e 's/$var(a) = $var(table) + "_%Y%m%d";/# doug removed -- $var(a) = $var(table) + "_%Y%m%d";/' $PATH_KAMAILIO_CFG
+sed -i -e 's/$var(a) = $var(table) + "_%Y%m%d";/# runscript removed -- $var(a) = $var(table) + "_%Y%m%d";/' $PATH_KAMAILIO_CFG
 
 # Make an alias, kinda.
 kamailio=$(which kamailio)


### PR DESCRIPTION
I was running into a couple issues addressed here...
#### Table 'homer_data.sip_capture_call_%Y%m%d' doesn't exist (changes to run.sh)

This might be due to the kamailio version as noted on the kamailio.cfg, however it was complaining a table wasn't found. (much details @ http://www.pasteall.org/63235 )

But the gist is that it would complain: 

```
 1(200) ERROR: db_mysql [km_dbase.c:124]: db_mysql_submit_query(): driver error on query: Table 'homer_data.sip_capture_call_%Y%m%d' doesn't exist (1146)
 4(203) ERROR: db_mysql [km_dbase.c:124]: db_mysql_submit_query(): driver error on query: Table 'homer_data.sip_capture_call_%Y%m%d' doesn't exist (1146)
 1(200) ERROR: <core> [db_query.c:235]: db_do_insert_cmd(): error while submitting query
```

So I modified kamailio.cfg in 

Another approach might be to change kamailio version in the container at the dockerfile? At any rate, this worked for me as a stop gap
#### Minor one: Expose UDP port (changes to README.md)

I wasn't seeing any traffic coming inside the container, and I realized the example `docker run` command didn't specify that port 9060 needed to be UDP, so I updated the readme to show that it should expose a UDP port.
