### PR TITLE
Updates run.sh to support using a mounted mysql volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,36 @@ docker pull qxip/homer-docker
 docker run -tid --name homer5 -p 80:80 -p 9060:9060/udp qxip/homer-docker
 ```
 
+### Running with a local MySQL
+
+By default, the container runs with a local instance of MySQL running. It may be of interest to run MySQL with a host directory mounted as a volume for MySQL data. This will help with keeping persistent data if you need to stop & remove the running container. (Which would otherwise delete the MySQL, without a mounted volume)
+
+You can run this container with a volume like so:
+
+```
+docker run -it -v /tmp/homermysql/:/var/lib/mysql --name homer5 -p 80:80 -p 9060:9060/udp dougbtv/homer5
+```
+
+### Running with an external MySQL
+
+If you'd like to run with an external MySQL, pass in the host information for the remote MySQL as entrypoint parameters at the end of your `docker run` command.
+
+```
+docker run -tid --name homer5 -p 80:80 -p 9060:9060/udp qxip/homer-docker --dbhost 10.0.0.1 --dbuser homer_user -dbpass homer_password
+```
+
+### Entrypoint Parameters
+
+```
+Homer5 Docker parameters:
+
+    --dbpass -p             MySQL password (homer_password)
+    --dbuser -u             MySQL user (homer_user)
+    --dbhost -h             MySQL host (127.0.0.1 [docker0 bridge])
+    --mypass -P             MySQL root local password (secret)
+    --hep    -H             Kamailio HEP Socket port (9060)
+```
+
 ### Local Build & Test
 ```
 git clone https://github.com/qxip/homer-docker; cd homer-docker


### PR DESCRIPTION
@lmangani here's my changes to allow it to (more elegantly) support using a mounted mysql volume. the overall idea is that if you mount a host directory into the container and store the mysql data there -- you can stop and remove the container -- without losing the mysql data. So you can run the container again and again, and the data is still there.

The basic gist is that after initially loading the data in run.sh, it creates a file in the mysqldata dir, and if it finds that file -- it doesn't try to load the data again. 

I'm pretty sure it was working OK without this change, but, it just makes the output when the container starts running look better, and I guess is over-all cleaner.

Also in other news, I've been running the container in production since I first opened an issue a while ago (3 weeks, maybe?) and I've been having very good luck. I had some hiccough where the UI wouldn't pull up detailed records with search, but, unfortunately I didn't look into it (I just restarted the container). Otherwise, it's been working very well for me. I'll report back with more findings.

-Doug
